### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#What's new in UIDynamics
+# What's new in UIDynamics
 This sample app roughly recreates the hoop physics of [Ball King](https://itunes.apple.com/us/app/ball-king/id946496840?mt=8) (which is a brilliant time waster, you should try it) using UIDynamics, showcasing the new addition to the API introduced in iOS 9.  
 
 Read more [here](http://fancypixel.github.io/blog/2015/06/19/playing-with-uidynamics-in-ios-9/).  
@@ -7,10 +7,10 @@ Read more [here](http://fancypixel.github.io/blog/2015/06/19/playing-with-uidyna
   <img width="500" height="820" src="assets/screenshot.gif"/>
 </p>
 
-#Setup
+# Setup
 This project requires Xcode 7. Just open the provided .xcodeproj.  
 
-#MIT License
+# MIT License
 
 	Copyright (c) 2015 Andrea Mazzini. All rights reserved.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
